### PR TITLE
Consider PAC for Android and add proxy change event

### DIFF
--- a/android/src/main/kotlin/com/victorblaess/native_flutter_proxy/FlutterProxyPlugin.kt
+++ b/android/src/main/kotlin/com/victorblaess/native_flutter_proxy/FlutterProxyPlugin.kt
@@ -9,9 +9,7 @@ import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo
 import android.net.Uri
-import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat.getSystemService
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
@@ -34,59 +32,51 @@ class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler, BroadcastReceiver()
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         setupChannel(binding.binaryMessenger)
         context = binding.applicationContext
+
+        // initial default proxy, that could not be captured beforehand
+        val pi = refreshProxyInfo(null) // this does not look consider proxies from PAC
+        Log.d("ProxyChangeReceiver", "Properties: ${System.getProperty("http.proxyHost")}:${System.getProperty("http.proxyPort")}")
+        Log.d("ProxyChangeReceiver", "ProxyInfo without intent: ${pi?.host}:${pi?.port}")
+
+        context!!.registerReceiver(this, IntentFilter(Proxy.PROXY_CHANGE_ACTION))
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         methodChannel?.setMethodCallHandler(null)
         methodChannel = null
-        unregisterReceiver()
-    }
-
-    private fun unregisterReceiver() {
-        ContextWrapper(context).unregisterReceiver(this)
+        context!!.unregisterReceiver(this)
+        context = null
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "getProxySetting") {
-            result.success(getProxySetting())
-        } else if (call.method == "setProxyChangeListenerEnabled") {
-            if (call.arguments<List<Boolean>>()?.get(0) == true) {
-                Log.d("ProxyChangeReceiver", "Enabled receiver")
-                context!!.registerReceiver(this, IntentFilter(Proxy.PROXY_CHANGE_ACTION))
-            } else {
-                Log.d("ProxyChangeReceiver", "Disabled receiver")
-                unregisterReceiver()
-            }
+            result.success(proxySetting)
         } else {
             result.notImplemented()
         }
     }
 
-    private fun getProxySetting(): Any? {
-        val map = LinkedHashMap<String, Any?>()
-        map["host"] = System.getProperty("http.proxyHost")
-        map["port"] = System.getProperty("http.proxyPort")
-        Log.d("ProxyChangeReceiver", "Properties: ${map["host"]}:${map["port"]}")
-        val pi = extractProxyInfo(null) // this does not look into PAC
-        Log.d("ProxyChangeReceiver", "ProxyInfo without intent: ${pi?.host}:${pi?.port}")
-        return map
-    }
+    private val proxySetting: LinkedHashMap<String, Any?> = LinkedHashMap<String, Any?>()
 
     override fun onReceive(context: Context, intent: Intent) {
         if (Proxy.PROXY_CHANGE_ACTION == intent.action) {
             // Handle the proxy change here
             Log.d("ProxyChangeReceiver", "Proxy settings changed")
-            val pi = extractProxyInfo(intent)
+            val pi = refreshProxyInfo(intent)
             Log.d("ProxyChangeReceiver", "ProxyInfo: ${pi?.host}:${pi?.port}")
-            methodChannel!!.invokeMethod("proxyChangedCallback", null)
+            methodChannel!!.invokeMethod("proxyChangedCallback", proxySetting)
         }
     }
 
-
-    private fun extractProxyInfo(intent: Intent?): ProxyInfo? {
+    /**
+     * Get system proxy and update cache with optional intent argument needed for PAC.
+     */
+    private fun refreshProxyInfo(intent: Intent?): ProxyInfo? {
         val connectivityManager = getSystemService(context!!,ConnectivityManager::class.java)
         var info: ProxyInfo? = connectivityManager!!.defaultProxy
         if (info == null) {
+            proxySetting["host"] = null
+            proxySetting["port"] = null
             return null
         }
 
@@ -100,18 +90,24 @@ class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler, BroadcastReceiver()
         // proxy is configured.
         if (info.pacFileUrl != null && info.pacFileUrl !== Uri.EMPTY) {
             if (intent == null) {
+                proxySetting["host"] = null
+                proxySetting["port"] = null
                 // PAC proxies are supported only when Intent is present
                 return null
             }
 
             val extras = intent.extras
             if (extras == null) {
+                proxySetting["host"] = null
+                proxySetting["port"] = null
                 return null
             }
 
-            info = extras.get("android.intent.extra.PROXY_INFO") as ProxyInfo?
+            info = extras.getParcelable("android.intent.extra.PROXY_INFO", ProxyInfo::class.java)
         }
 
+        proxySetting["host"] = info!!.host
+        proxySetting["port"] = info.port
         return info
     }
 }

--- a/android/src/main/kotlin/com/victorblaess/native_flutter_proxy/FlutterProxyPlugin.kt
+++ b/android/src/main/kotlin/com/victorblaess/native_flutter_proxy/FlutterProxyPlugin.kt
@@ -1,16 +1,30 @@
 package com.victorblaess.native_flutter_proxy
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Proxy
+import android.net.ProxyInfo
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat.getSystemService
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import java.util.LinkedHashMap
 
-class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler {
+
+class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler, BroadcastReceiver() {
 
     private var methodChannel: MethodChannel? = null
+    private var context: Context? = null
 
     private fun setupChannel(messenger: BinaryMessenger) {
         methodChannel = MethodChannel(messenger, "native_flutter_proxy")
@@ -19,16 +33,30 @@ class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler {
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         setupChannel(binding.binaryMessenger)
+        context = binding.applicationContext
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         methodChannel?.setMethodCallHandler(null)
         methodChannel = null
+        unregisterReceiver()
+    }
+
+    private fun unregisterReceiver() {
+        ContextWrapper(context).unregisterReceiver(this)
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "getProxySetting") {
             result.success(getProxySetting())
+        } else if (call.method == "setProxyChangeListenerEnabled") {
+            if (call.arguments<List<Boolean>>()?.get(0) == true) {
+                Log.d("ProxyChangeReceiver", "Enabled receiver")
+                context!!.registerReceiver(this, IntentFilter(Proxy.PROXY_CHANGE_ACTION))
+            } else {
+                Log.d("ProxyChangeReceiver", "Disabled receiver")
+                unregisterReceiver()
+            }
         } else {
             result.notImplemented()
         }
@@ -38,6 +66,52 @@ class FlutterProxyPlugin : FlutterPlugin, MethodCallHandler {
         val map = LinkedHashMap<String, Any?>()
         map["host"] = System.getProperty("http.proxyHost")
         map["port"] = System.getProperty("http.proxyPort")
+        Log.d("ProxyChangeReceiver", "Properties: ${map["host"]}:${map["port"]}")
+        val pi = extractProxyInfo(null) // this does not look into PAC
+        Log.d("ProxyChangeReceiver", "ProxyInfo without intent: ${pi?.host}:${pi?.port}")
         return map
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (Proxy.PROXY_CHANGE_ACTION == intent.action) {
+            // Handle the proxy change here
+            Log.d("ProxyChangeReceiver", "Proxy settings changed")
+            val pi = extractProxyInfo(intent)
+            Log.d("ProxyChangeReceiver", "ProxyInfo: ${pi?.host}:${pi?.port}")
+            methodChannel!!.invokeMethod("proxyChangedCallback", null)
+        }
+    }
+
+
+    private fun extractProxyInfo(intent: Intent?): ProxyInfo? {
+        val connectivityManager = getSystemService(context!!,ConnectivityManager::class.java)
+        var info: ProxyInfo? = connectivityManager!!.defaultProxy
+        if (info == null) {
+            return null
+        }
+
+        // If a proxy is configured using the PAC file use
+        // Android's injected localhost HTTP proxy.
+        //
+        // Android's injected localhost proxy can be accessed using a proxy host
+        // equal to `localhost` and a proxy port retrieved from intent's 'extras'.
+        // We cannot take a proxy port from the ProxyInfo object that's exposed by
+        // the connectivity manager as it's always equal to -1 for cases when PAC
+        // proxy is configured.
+        if (info.pacFileUrl != null && info.pacFileUrl !== Uri.EMPTY) {
+            if (intent == null) {
+                // PAC proxies are supported only when Intent is present
+                return null
+            }
+
+            val extras = intent.extras
+            if (extras == null) {
+                return null
+            }
+
+            info = extras.get("android.intent.extra.PROXY_INFO") as ProxyInfo?
+        }
+
+        return info
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ void main() async {
 
   try {
     final settings = await NativeProxyReader.proxySetting;
+    NativeProxyReader.setProxyChangedCallback((a) async => debugPrint('Callback for proxy change'));
     enabled = settings.enabled;
     host = settings.host;
     port = settings.port;

--- a/lib/src/native_proxy_reader.dart
+++ b/lib/src/native_proxy_reader.dart
@@ -18,12 +18,25 @@ import 'package:flutter/services.dart';
 /// ```
 /// {@endtemplate}
 abstract final class NativeProxyReader {
-  /// Method channel for native platform communication.ƒ
+  /// Method channel for native platform communication.
   static const _channel = MethodChannel('native_flutter_proxy');
 
   /// Get the proxy settings from the native platform.
   static Future<ProxySetting> get proxySetting async {
     return _channel.invokeMapMethod<String, dynamic>('getProxySetting').then(ProxySetting._fromMap);
+  }
+
+  /// Register callback, when the system proxy is changed.
+  /// This is the only way to use a proxy specified by PAC.
+  static void setProxyChangedCallback(Future<dynamic> Function(ProxySetting)? handler) {
+    _channel..invokeMethod('setProxyChangeListenerEnabled', [handler != null])
+    ..setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'proxyChangedCallback':
+          if (handler != null) await handler(await proxySetting);
+        default: throw MissingPluginException('notImplemented');
+      }
+    });
   }
 }
 

--- a/lib/src/native_proxy_reader.dart
+++ b/lib/src/native_proxy_reader.dart
@@ -29,12 +29,12 @@ abstract final class NativeProxyReader {
   /// Register callback, when the system proxy is changed.
   /// This is the only way to use a proxy specified by PAC.
   static void setProxyChangedCallback(Future<dynamic> Function(ProxySetting)? handler) {
-    _channel..invokeMethod('setProxyChangeListenerEnabled', [handler != null])
-    ..setMethodCallHandler((call) async {
-      switch (call.method) {
-        case 'proxyChangedCallback':
-          if (handler != null) await handler(await proxySetting);
-        default: throw MissingPluginException('notImplemented');
+    _channel.setMethodCallHandler((call) async {
+      if (handler != null && call.method == 'proxyChangedCallback' && call.arguments is Map<Object?, Object?>) {
+        final map = (call.arguments as Map<Object?, Object?>).cast<String, dynamic>();
+        await handler(ProxySetting._fromMap(map));
+      } else {
+        throw MissingPluginException('notImplemented');
       }
     });
   }


### PR DESCRIPTION
Proxies configured with Automatic scripts are not detected with this package until now. I also wanted to have an event for proxy changes so I can adjust my override. I thought a general callback is the best solution.

NOTE: This PR changes the way to acquire the proxy details fundamentally. This approach should be more future-proof as this is following the standard way to obtain proxy details on android.